### PR TITLE
rust: add language support

### DIFF
--- a/lisp/evil-ts-obj-rust.el
+++ b/lisp/evil-ts-obj-rust.el
@@ -1,0 +1,188 @@
+;;; evil-ts-obj-rust.el --- Rust setting for evil-ts-obj -*- lexical-binding: t; -*-
+;;; Commentary:
+;;
+;;  rust setting for evil-ts-obj
+;;
+;;; Code:
+
+
+(require 'evil-ts-obj-def)
+
+(defcustom evil-ts-obj-rust-compound-nodes
+  '("struct_item"
+    "enum_item"
+    "trait_item"
+    "union_item"
+    "impl_item"
+    "function_item"
+    "closure_expression"
+    "if_expression"
+    "else_clause"
+    "while_expression"
+    "for_expression"
+    "loop_expression"
+    "match_expression"
+    "expression_statement"
+    "match_arm")
+  "Nodes that designate compound statement in rust."
+  :type '(repeat string)
+  :group 'evil-ts-obj)
+
+(defvar evil-ts-obj-rust-statement-regex nil
+  "Regex is composed from `evil-ts-obj-rust-statement-nodes'.")
+
+(defcustom evil-ts-obj-rust-statement-nodes
+  '("type_item"
+    "const_item"
+    "static_item"
+    "field_declaration"
+    "let_declaration"
+    "expression_statement"
+    "return_expression"
+    "call_expression")
+  "Nodes that designate simple statement in rust."
+  :type '(repeat string)
+  :group 'evil-ts-obj
+  :set #'evil-ts-obj-conf-nodes-setter)
+
+(defcustom evil-ts-obj-rust-statement-seps
+  '("&&" "||")
+  "Separators for rust statements."
+  :type '(repeat string)
+  :group 'evil-ts-obj)
+
+(defun evil-ts-obj-rust-compound-pred (node)
+  "Return t if NODE is a compound thing.
+Consider NODE to be a compound if it is an expression_statement holding
+other compounds."
+  (let ((res
+  (pcase (treesit-node-type node)
+    ("expression_statement"
+     (when-let ((child (treesit-node-child node 0))
+                (child-type (treesit-node-type child)))
+       (member child-type evil-ts-obj-rust-compound-nodes)))
+    (_
+     t))))
+    res))
+
+(defun evil-ts-obj-rust-statement-pred (node)
+  "Return t if NODE is a statement thing.
+Consider NODE to be a statement if it is used as condition in a
+compound statement or it is a part of a boolean expression, or if
+its type is matched against `evil-ts-obj-rust-statement-regex'."
+
+  (or (evil-ts-obj--by-field-name-pred node '((nil . "condition")
+                                              ;; rhs
+                                              ("let_declaration" . "value")
+                                              ("assignment_expression" . "right")))
+      ;; parts of boolean expressions
+      (evil-ts-obj--common-bool-expr-pred node "binary_expression"
+                                          evil-ts-obj-rust-statement-seps)
+      (string-match-p evil-ts-obj-rust-statement-regex (treesit-node-type node))))
+
+
+(defvar evil-ts-obj-rust-param-parent-regex nil
+  "Regex is composed from `evil-ts-obj-rust-param-parent-nodes'.")
+
+(defcustom evil-ts-obj-rust-param-parent-nodes
+  '("parameters"
+    "closure_parameters"
+    "arguments"
+    "type_arguments"
+    "type_parameters"
+    "array_expression"
+    "where_clause"
+    "token_tree") ;; best effort to support function-call like macro invocations, like println!(),  vec![], #[attr()]
+  "Parent nodes for a parameter thing in rust."
+  :type '(repeat string)
+  :group 'evil-ts-obj
+  :set #'evil-ts-obj-conf-nodes-setter)
+
+(defcustom evil-ts-obj-rust-param-seps
+  '(",")
+  "Separators for rust params."
+  :type '(repeat string)
+  :group 'evil-ts-obj)
+
+(defcustom evil-ts-obj-rust-things
+  `((compound ,(cons (evil-ts-obj-conf--make-nodes-regex evil-ts-obj-rust-compound-nodes) #'evil-ts-obj-rust-compound-pred))
+    (statement evil-ts-obj-rust-statement-pred)
+    (param ,(lambda (n) (evil-ts-obj-common-param-pred evil-ts-obj-rust-param-parent-regex n))))
+  "Things for rust."
+  :type 'plist
+  :group 'evil-ts-obj)
+
+
+(defun evil-ts-obj-rust-extract-compound-inner (node)
+  "Return range for a compound inner text object.
+Compound is represented by a `NODE'."
+  (if (equal (treesit-node-type node) "expression_statement")
+    (evil-ts-obj-rust-extract-compound-inner (treesit-node-child node -1))
+    (when-let ((body-node
+              (pcase (treesit-node-type node)
+                ("if_expression"
+                 (treesit-node-child-by-field-name node "consequence"))
+                ((or "else_clause" "match_arm")
+                 (treesit-node-child node -1 t))
+                (_
+                 (treesit-node-child-by-field-name node "body")))))
+    (if (member (treesit-node-type body-node) '("field_declaration_list" ;; struct/enum/trait fields
+                                                "declaration_list" ;; impl blocks
+                                                "block")) ;; bare { ... } blocks
+        ;; do not include enclosing braces
+        (if-let ((first-child (treesit-node-child body-node 0 t))
+                 (last-child  (treesit-node-child body-node -1 t)))
+            (list (treesit-node-start first-child)
+                  (treesit-node-end last-child))
+          ;; empty body
+          (list (treesit-node-end (treesit-node-child body-node 0))
+                (treesit-node-start (treesit-node-child body-node 1))))
+
+      (list (treesit-node-start body-node)
+            (treesit-node-end body-node))))))
+
+(defun evil-ts-obj-rust-compound-outer-ext (node)
+  "Extend a compound range to include preceding attributes.
+Current thing is represented by `NODE'."
+  (let ((start (treesit-node-start node))
+        (end (treesit-node-end node))
+        (prev-node (treesit-node-prev-sibling node)))
+    (while (equal (treesit-node-type prev-node) "attribute_item")
+      (setq start (treesit-node-start prev-node))
+      (setq prev-node (treesit-node-prev-sibling prev-node)))
+    (list start end)))
+
+(defun evil-ts-obj-rust-ext (spec node)
+  "Main extension function for rust.
+See `evil-ts-obj-conf-thing-modifiers' for details about `SPEC'
+and `NODE'."
+  (pcase spec
+    ((pmap (:thing 'compound) (:mod 'inner))
+     (evil-ts-obj-rust-extract-compound-inner node))
+    ((pmap (:thing 'compound) (:mod 'outer) (:act 'op))
+     (evil-ts-obj-rust-compound-outer-ext node))))
+
+
+(defcustom evil-ts-obj-rust-ext-func
+  #'evil-ts-obj-rust-ext
+  "Extension function for rust."
+  :type 'function
+  :group 'evil-ts-obj)
+
+
+;;;###autoload
+(defun evil-ts-obj-rust-setup-things ()
+  "Set all variables needed by evil-ts-obj-rustore."
+  (evil-ts-obj-def-init-lang 'rust evil-ts-obj-rust-things
+                             :ext-func evil-ts-obj-rust-ext-func
+                             :param-seps evil-ts-obj-rust-param-seps
+                             :statement-seps evil-ts-obj-rust-statement-seps
+                             :terms '(";")
+                             :statement-sib-trav
+                             (evil-ts-obj-trav-create
+                              :fetcher (lambda (d n) (evil-ts-obj--common-get-statement-sibling
+                                                      d n '("binary_expression"))))
+                             :compound-brackets "{}"))
+
+(provide 'evil-ts-obj-rust)
+;;; evil-ts-obj-rust.el ends here

--- a/lisp/evil-ts-obj.el
+++ b/lisp/evil-ts-obj.el
@@ -25,6 +25,7 @@
 (require 'evil-ts-obj-python)
 (require 'evil-ts-obj-bash)
 (require 'evil-ts-obj-cpp)
+(require 'evil-ts-obj-rust)
 
 (require 'evil-ts-obj-nix)
 (require 'evil-ts-obj-yaml)

--- a/test/evil-ts-obj-rust-resources/edit.erts
+++ b/test/evil-ts-obj-rust-resources/edit.erts
@@ -1,0 +1,946 @@
+Point-Char: |
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-drag-up 1))
+
+Name: drag up t1
+
+=-=
+struct S1 {}
+
+impl S1 {
+    fn func1(self, i: usize, j: usize) -> usize {
+        return i + j;
+    }
+    fn |func2() {}
+}
+=-=
+struct S1 {}
+
+impl S1 {
+    |fn func2() {}
+    fn func1(self, i: usize, j: usize) -> usize {
+        return i + j;
+    }
+}
+=-=-=
+
+Name: drag up t2
+
+=-=
+fn func () {
+   let i = 3;
+   |call(i);
+}
+=-=
+fn func () {
+   |call(i);
+   let i = 3;
+}
+=-=-=
+
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-clone-after-dwim))
+
+Name: Clone after dwim t1
+
+=-=
+while true { 
+    |i += 1;
+}
+=-=
+while true { 
+    |i += 1;
+    i += 1;
+}
+=-=-=
+
+Name: Clone after dwim t2
+
+=-=
+|while true { 
+    i += 1;
+}
+=-=
+|while true { 
+    i += 1;
+}
+while true { 
+    i += 1;
+}
+=-=-=
+
+Name: Clone after dwim t3
+
+=-=
+struct |St<T> {}
+=-=
+struct |St<T> {}
+struct St<T> {}
+=-=-=
+
+Name: Clone after dwim t4
+
+=-=
+struct St<T, |U> {}
+=-=
+struct St<T, |U, U> {}
+=-=-=
+
+Name: Clone after dwim t5
+Skip: t
+
+=-=
+if |opts && (!i || i < 0 < 3) && t.call() || true  {
+}
+=-=
+if |opts && opts && (!i || i < 0 < 3) && t.call() || true  {
+}
+=-=-=
+
+Name: Clone after dwim t6
+Skip: t
+
+=-=
+if opts && |(!i || i < 0 < 3) && t.call() || true  {
+}
+=-=
+if |opts && |(!i || i < 0 < 3) && (!i || i < 0 < 3) && t.call() || true  {
+}
+=-=-=
+
+Name: Clone after dwim t7
+Skip: t
+
+=-=
+if |opts && (!i || i < 0 < 3) && t.call() || |true  {
+}
+=-=
+if |opts && (!i || i < 0 < 3) && t.call() || |true || true  {
+}
+=-=-=
+
+Name: Clone after dwim t8
+
+=-=
+if true {
+    let comp = true && false && |call();
+}
+=-=
+if true {
+    let comp = true && false && |call() && call();
+}
+=-=-=
+
+Name: Clone after dwim t9
+Skip: t
+
+=-=
+if true {
+    let comp = |true && false && call();
+}
+=-=
+if true {
+    let comp = |true && true && false && call();
+}
+=-=-=
+
+Name: Clone after dwim t10
+
+=-=
+if true {
+    |let comp = true && false && call();
+    call2();
+}
+=-=
+if true {
+    |let comp = true && false && call();
+    let comp = true && false && call();
+    call2();
+}
+=-=-=
+
+Name: Clone after dwim t11
+
+=-=
+if true {
+    let comp = true && false;
+    |res = sort(items_hld, comp);
+    items_hld.props.sorted.by_key = true;
+}
+=-=
+if true {
+    let comp = true && false;
+    |res = sort(items_hld, comp);
+    res = sort(items_hld, comp);
+    items_hld.props.sorted.by_key = true;
+}
+=-=-=
+Name: Clone after dwim t12
+
+=-=
+if true {
+    let comp = true && false;
+    res = |sort(items_hld, comp);
+    items_hld.props.sorted.by_key = true;
+}
+=-=
+if true {
+    let comp = true && false;
+    res = |sort(items_hld, comp) sort(items_hld, comp);
+    items_hld.props.sorted.by_key = true;
+}
+=-=-=
+
+Name: Clone after dwim t13
+
+=-=
+if true {
+    let comp = true && false;
+    |call(comp);
+}
+=-=
+if true {
+    let comp = true && false;
+    |call(comp);
+    call(comp);
+}
+=-=-=
+
+Name: Clone after dwim t14
+
+=-=
+if true {
+    let comp = true && false;
+   | call(comp);
+}
+=-=
+if true {
+    let comp = true && false;
+   | call(comp);
+    call(comp);
+}
+=-=-=
+
+Name: Clone after dwim t15
+
+=-=
+if true {
+    let comp = |call() + 1;
+    return comp;
+}
+=-=
+if true {
+    let comp = |call() call() + 1;
+    return comp;
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-extract-up-dwim 1)
+    (delete-trailing-whitespace))
+
+Name: Extract dwim up t1
+
+=-=
+fn f() {
+    if |i > 0 {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    |i > 0
+    if  {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=-=
+
+Name: Extract dwim up t2
+
+=-=
+fn f() {
+    if i > 0 {
+        |i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    |i -= 1;
+    if i > 0 {
+
+    } else {
+        i += 2;
+    }
+}
+=-=-=
+
+Name: Extract dwim up t3
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else {
+        |i += 2;
+    }
+}
+=-=
+fn f() {
+    |i += 2;
+    if i > 0 {
+        i -= 1;
+    } else {
+
+    }
+}
+=-=-=
+
+Name: Extract dwim up t4
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } |else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    |else {
+        i += 2;
+    }
+    if i > 0 {
+        i -= 1;
+    }
+}
+=-=-=
+
+Name: Extract dwim up t5
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else |if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    |if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+    if i > 0 {
+        i -= 1;
+    } else {}
+}
+=-=-=
+
+Name: Extract dwim up t6
+
+=-=
+fn f() {
+    {
+        |let a = 5;
+    }
+}
+=-=
+fn f() {
+    |let a = 5;
+    {
+
+    }
+}
+=-=-=
+
+Name: Extract dwim up t7
+
+=-=
+fn f() {
+    let a = {
+      |i += 1;
+      5
+    }
+}
+=-=
+fn f() {
+    |i += 1;
+    let a = {
+
+      5
+    }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-extract-up-dwim 2)
+    (delete-trailing-whitespace))
+
+Name: Extract dwim up two levels t1
+
+=-=
+fn f() {
+    if |i > 0 {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=
+|i > 0
+fn f() {
+    if  {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=-=
+
+Name: Extract dwim up two levels t2
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else |if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+}
+=-=
+|if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else {}
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-extract-down-dwim 1)
+    (delete-trailing-whitespace))
+
+Name: Extract dwim down t1
+
+=-=
+fn f() {
+    if |i > 0 {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    if  {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+    |i > 0
+}
+=-=-=
+
+Name: Extract dwim down t2
+
+=-=
+fn f() {
+    if i > 0 {
+        |i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    if i > 0 {
+
+    } else {
+        i += 2;
+    }
+    |i -= 1;
+}
+=-=-=
+
+Name: Extract dwim down t3
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else {
+        |i += 2;
+    }
+}
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else {
+
+    }
+    |i += 2;
+}
+=-=-=
+
+Name: Extract dwim down t4
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } |else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    }
+    |else {
+        i += 2;
+    }
+}
+=-=-=
+
+Name: Extract dwim down t5
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else |if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else {}
+    |if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-extract-down-dwim 2)
+    (delete-trailing-whitespace))
+
+Name: Extract dwim down two levels t1
+
+=-=
+fn f() {
+    if |i > 0 {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    if  {
+        i -= 1;
+    } else {
+        i += 2;
+    }
+}
+|i > 0
+=-=-=
+
+Name: Extract dwim down two levels t2
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else |if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+}
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+    } else {}
+}
+|if i < 0 {
+        i += 1;
+        println!();
+    } else {
+        i += 2;
+    }
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-inject-down-dwim 1)
+    (delete-trailing-whitespace))
+
+Name: Inject down dwim  t1
+
+=-=
+fn f() {
+    |let i = 3;
+    if i > 0 {
+        i -= 1;
+    }
+    if true {}
+}
+=-=
+fn f() {
+
+    if i > 0 {
+        |let i = 3;
+        i -= 1;
+    }
+    if true {}
+}
+=-=-=
+
+Name: Inject down dwim  t2
+
+=-=
+fn f() {
+    |let mut i = 3;
+    i += 1;
+
+    if (i > 0){
+        i--;
+    }
+}
+=-=
+fn f() {
+
+    i += 1;
+
+    if (i > 0){
+        |let mut i = 3;
+        i--;
+    }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-inject-down-dwim 2)
+    (delete-trailing-whitespace))
+
+Name: Inject down dwim two levels t1
+
+=-=
+fn f() {
+    |let i = 3;
+    if i > 0 {
+        while i < 5 {
+            i -= 1;
+        }
+    }
+}
+=-=
+fn f() {
+
+    if i > 0 {
+        while i < 5 {
+            |let i = 3;
+            i -= 1;
+        }
+    }
+}
+=-=-=
+
+Name: Inject down dwim two levels t2
+
+=-=
+fn f() {
+    |let i = 3;
+    if i > 0 {
+        i = call(i);
+        while i < 5 {
+            i -= 1;
+        }
+    }
+}
+=-=
+fn f() {
+
+    if i > 0 {
+        i = call(i);
+        while i < 5 {
+            |let i = 3;
+            i -= 1;
+        }
+    }
+}
+=-=-=
+
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-inject-up-dwim 1)
+    (delete-trailing-whitespace))
+
+Name: Inject up dwim  t1
+
+=-=
+fn f() {
+    i += 1;
+    if i > 0 {
+        i -= 1;
+    }
+    |i = 3;
+}
+=-=
+fn f() {
+    i += 1;
+    if i > 0 {
+        i -= 1;
+        |i = 3;
+    }
+
+}
+=-=-=
+
+Name: Inject up dwim  t2
+
+=-=
+fn f() {
+    if i > 3 {
+        i -= 1;
+    }
+    i += 1;
+    if i > 0 {
+        i -= 1;
+    }
+    i += 1;
+    |i = 3;
+}
+=-=
+fn f() {
+    if i > 3 {
+        i -= 1;
+    }
+    i += 1;
+    if i > 0 {
+        i -= 1;
+        |i = 3;
+    }
+    i += 1;
+
+}
+=-=-=
+
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-inject-up-dwim 2)
+    (delete-trailing-whitespace))
+
+Name: Inject up dwim two levels t1
+
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+        if i > 3 {
+            i -= 1;
+            i -= 1;
+        }
+    }
+    i += 1;
+    |i = 3;
+}
+=-=
+fn f() {
+    if i > 0 {
+        i -= 1;
+        if i > 3 {
+            i -= 1;
+            i -= 1;
+            |i = 3;
+        }
+    }
+    i += 1;
+
+}
+=-=-=
+
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-slurp 1)
+    (delete-trailing-whitespace))
+
+Name: Slurp t1
+
+=-=
+fn f() {
+    i += 1;
+    if i > 0 {
+       | i -= 1;
+    }
+    i = 3;
+}
+=-=
+fn f() {
+    i += 1;
+    if i > 0 {
+       | i -= 1;
+        i = 3;
+    }
+
+}
+=-=-=
+
+Name: Slurp t3
+
+=-=
+fn f() {
+    i += 1;
+    |if i > 0 {
+        i -= 1;
+    }
+    i = 3;
+}
+=-=
+fn f() {
+
+    |if i > 0 {
+        i += 1;
+        i -= 1;
+    }
+    i = 3;
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-barf 1)
+    (delete-trailing-whitespace))
+
+Name: Barf t1
+
+=-=
+fn f() {
+    i += 1;
+    if i > 0 {
+        |i -= 1;
+        i = 3;
+    }
+}
+=-=
+fn f() {
+    i += 1;
+    if i > 0 {
+        |i -= 1;
+
+    }
+    i = 3;
+}
+=-=-=
+
+Name: Barf t3
+
+=-=
+fn f() {
+    |if i > 0 {
+       i += 1;
+       i -= 1;
+    }
+    i = 3;
+}
+=-=
+fn f() {
+    i += 1;
+    |if i > 0 {
+
+       i -= 1;
+    }
+    i = 3;
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-convolute 1)
+    (delete-trailing-whitespace))
+
+
+Name: Convolute statements t2
+
+=-=
+while true {
+    let temp = value;
+    if reply && temp {
+        |ReplyWithCallReply(ctx, reply);
+        MODULE_OK
+    } else {
+        WithError(ctx, "ERR")
+    }
+}
+
+=-=
+if reply && temp {
+    while true {
+        let temp = value;
+        |ReplyWithCallReply(ctx, reply);
+    }
+    MODULE_OK
+} else {
+    WithError(ctx, "ERR")
+}
+=-=-=

--- a/test/evil-ts-obj-rust-resources/movement.erts
+++ b/test/evil-ts-obj-rust-resources/movement.erts
@@ -1,0 +1,81 @@
+Point-Char: |
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-previous-sibling))
+
+Name: Move to previous largest t1
+
+=-=
+fn func1(T t, U u) {
+    ()
+}
+
+|fn func2(T t, U u) {
+    ()
+}
+=-=
+|fn func1(T t, U u) {
+    ()
+}
+
+fn func2(T t, U u) {
+    ()
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-next-sibling))
+
+Name: Move to next largest t1
+
+=-=
+|fn func2(){
+    ()
+}
+
+struct St {}
+=-=
+fn func2(){
+    ()
+}
+
+|struct St {}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-beginning-of-thing))
+
+Name: Move to beginning of t1
+
+=-=
+fn func2(){
+|
+}
+=-=
+|fn func2(){
+
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (evil-ts-obj-end-of-thing))
+
+Name: Move to end of t1
+
+=-=
+fn func2(){
+|
+}
+=-=
+fn func2(){
+
+|}
+=-=-=

--- a/test/evil-ts-obj-rust-resources/text-objects.erts
+++ b/test/evil-ts-obj-rust-resources/text-objects.erts
@@ -1,0 +1,526 @@
+Point-Char: |
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-compound-outer)))
+
+Name: Delete for loop outer t1
+
+=-=
+fn func () {
+    for i in 1..10 {
+        |println!("{i}");
+    }
+}
+=-=
+fn func () {
+    |
+}
+=-=-=
+
+Name: Delete if outer t1
+
+=-=
+if |i > 0 {
+    i -= 1;
+} else if i < 0 {
+    i += 1;
+    println!();
+} else {
+    i n+= 2;
+}
+=-=
+|
+=-=-=
+
+Name: Delete if outer t2
+
+=-=
+if i > 0 {
+    i -= 1;
+} else if i < 0 {
+    i += 1;
+    println!();
+} else {
+    |i += 2;
+}
+=-=
+if i > 0 {
+    i -= 1;
+} else if i < 0 {
+    i += 1;
+    println!();
+} |
+=-=-=
+
+
+Name: Delete if outer t3
+
+=-=
+if i > 0 {
+    i -= 1;
+} el|se if i < 0 {
+    i += 1;
+    println!();
+} else {
+    i += 2;
+}
+=-=
+if i > 0 {
+    i -= 1;
+} |
+=-=-=
+
+Name: Delete if outer t4
+
+=-=
+if i > 0 {
+    i -= 1;
+} else if i |< 0 {
+    i += 1;
+    println!();
+} else {
+    i += 2;
+}
+=-=
+if i > 0 {
+    i -= 1;
+} else |
+=-=-=
+
+Name: Delete struct outer t1
+
+=-=
+struct St {
+    |s: String;
+}
+=-=
+|
+=-=-=
+
+Name: Delete generic function t1
+
+=-=
+fn calc<T,U> (t: T, u: U) -> usize
+where
+    T: Default,
+    U: Display,
+{
+    |t + u
+}
+=-=
+|
+=-=-=
+
+Name: Delete generic method t1
+
+=-=
+impl<T,U> St<T,U> {
+    fn calc(self, t: T, u: U) -> f32 {
+        |t + u
+    }
+}
+=-=
+impl<T,U> St<T,U> {
+    |
+}
+=-=-=
+
+Name: Delete impl block outer t1
+
+=-=
+impl<T,U> St<T,U> |{
+    fn calc(self, t: T, u: U) -> f32 {
+        t + u
+    }
+}
+=-=
+|
+=-=-=
+
+Name: Delete empty compound outer t1
+
+=-=
+fn func() {
+    loop {
+    |
+    }
+}
+=-=
+fn func() {
+    |
+}
+=-=-=
+
+Name: Delete next compound outer t1
+
+=-=
+fn func() {
+|
+while true {
+
+    }
+}
+=-=
+fn func() {
+
+|
+}
+=-=-=
+
+Name: Delete function with attribute t1
+
+=-=
+#[attr]
+fn func() {
+    |
+}
+=-=
+
+=-=-=
+
+Name: Delete function with attribute t2
+
+=-=
+#[attr1]
+#[attr2]
+fn func() {
+    |
+}
+=-=
+
+=-=-=
+
+Name: Delete struct with attribute t1
+
+=-=
+#[attr1]
+struct S {
+    |
+}
+=-=
+
+=-=-=
+
+Name: Delete struct with attribute t2
+
+=-=
+#[attr1]
+#[attr2]
+struct S {
+    |
+}
+=-=
+
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-compound-inner)))
+
+Name: Delete for loop inner t1
+
+=-=
+fn func () {
+    for i in 1..10 {
+        |println!("{i}");
+    }
+}
+=-=
+fn func () {
+    for i in 1..10 {
+        |
+    }
+}
+=-=-=
+
+Name: Delete for loop inner t2
+
+=-=
+for |i in 1..10 {
+    i += 1;
+}
+=-=
+for i in 1..10 {
+    |
+}
+=-=-=
+
+Name: Delete if inner t1
+
+=-=
+|if i > 0 {
+    i -= 1;
+} else {
+    i += 2;
+}
+=-=
+if i > 0 {
+    |
+} else {
+    i += 2;
+}
+=-=-=
+
+Name: Delete if inner t2
+
+=-=
+if i > 0 {
+    i -= 1;
+}| else {
+    i += 2;
+}
+=-=
+if i > 0 {
+    i -= 1;
+} else {
+    |
+}
+=-=-=
+
+Name: Delete if inner t3
+
+=-=
+if (i > 0) {
+    i--;
+} |else {
+    i+=2;
+}
+=-=
+if (i > 0) {
+    i--;
+} else {
+    |
+}
+=-=-=
+
+Name: Delete match inner t1
+
+=-=
+match i {
+    |1 => println!("1"),
+}
+=-=
+match i {
+    1 => |,
+}
+=-=-=
+
+Name: Delete struct inner t1
+
+=-=
+stru|ct St {
+    s: String;
+}
+=-=
+struct St {
+    |
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-param-outer)))
+
+Name: Delete param outer t1
+
+=-=
+fn func(i: i32, map: &|HashMap<String, i32>, s: String){
+}
+=-=
+fn func(i: i32, |s: String){
+}
+=-=-=
+
+Name: Delete param outer t2
+
+=-=
+struct St<T : Display + Debug, U: |Iterator<Item=usize>> { }
+=-=
+struct St<T : Display + Debug> { }
+=-=-=
+
+Name: Delete param outer t3
+
+=-=
+struct St<T : Display + Debug, U: Iterator<Item=|usize>> { }
+=-=
+struct St<T : Display + Debug, U: Iterator<|>> { }
+=-=-=
+
+Name: Delete param outer t4
+
+=-=
+fn calc<T,U> (t: T, u: U) -> usize
+where
+    |T: Default,
+    U: Display,
+{
+    t + u
+}
+=-=
+fn calc<T,U> (t: T, u: U) -> usize
+where
+    |U: Display,
+{
+    t + u
+}
+=-=-=
+
+Name: Delete param outer t5
+
+=-=
+#![attr(|foo, bar)]
+=-=
+#![attr(bar)]
+=-=-=
+
+Name: Delete param outer t6
+
+=-=
+vec![1, 2|, 3]
+=-=
+vec![1, 3]
+=-=-=
+
+Name: Delete param outer t7
+
+=-=
+println!("{}, {}", |"Hello", "World")
+=-=
+println!("{}, {}", "World")
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-param-lower)))
+
+Name: Delete param lower t1
+
+=-=
+let a = [1+1, 2|+2, 3+3];
+=-=
+let a = [1+1, |];
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-param-LOWER)))
+
+Name: Delete param LOWER t1
+
+=-=
+let a = [1+1, 2|+2, 3+3];
+=-=
+let a = [1+1|];
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-param-upper)))
+
+Name: Delete param upper t1
+
+=-=
+let a = [1+1, 2|+2, 3+3];
+=-=
+let a = [|, 3+3];
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-param-UPPER)))
+
+Name: Delete param UPPER t1
+
+=-=
+let a = [1+1, 2|+2, 3+3];
+=-=
+let a = [|3+3];
+=-=-=
+
+Code:
+  (lambda ()
+    (evil-ts-obj-rust-tests-setup)
+    (apply #'evil-delete (evil-ts-obj-statement-outer)))
+
+Name: Delete statement outer t1
+Point-Char: _
+
+=-=
+if o_pts && (!i || i < 0 < 3) && t.call() || true {}
+=-=
+if _(!i || i < 0 < 3) && t.call() || true {}
+=-=-=
+
+Name: Delete statement outer t2
+
+=-=
+if opts && (!i || i < 0 < 3) && _t.call() || true {}
+=-=
+if opts && (!i || i < 0 < 3) && _true {}
+=-=-=
+
+Name: Delete statement outer t3
+
+=-=
+if opts && (!i || i < 0 < 3) && t.call() || t_rue {}
+=-=
+if opts && (!i || i < 0 < 3) && t.call()_ {}
+=-=-=
+
+Name: Delete statement outer t4
+
+=-=
+if opts && (!i || i < _0 < 3) && t.call() || true {}
+=-=
+if opts && (!i_) && t.call() || true {}
+=-=-=
+
+Name: Delete statement outer t5
+
+=-=
+if_ opts && (!i || i < 0 < 3) && t.call() || true {}
+=-=
+if _ {}
+=-=-=
+
+Name: Delete statement outer t6
+Point-Char: |
+
+=-=
+if t|rue {}
+=-=
+if | {}
+=-=-=
+
+Name: Delete statement outer t7
+
+=-=
+while i < |3 {}
+=-=
+while | {}
+=-=-=
+
+Name: Delete statement outer t8
+
+=-=
+let i = |5 * 2;
+=-=
+let i = |;
+=-=-=
+
+Name: Delete statement outer t9
+
+=-=
+i = |5 * 2;
+=-=
+i = |;
+=-=-=

--- a/test/evil-ts-obj-rust-tests.el
+++ b/test/evil-ts-obj-rust-tests.el
@@ -1,0 +1,35 @@
+;;; evil-ts-obj-cpp-tests.el --- rust tests -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+
+(require 'ert)
+(require 'ert-x)
+(require 'treesit)
+(require 'evil)
+(require 'evil-ts-obj)
+(require 'evil-ts-obj-rust)
+
+(defun evil-ts-obj-rust-tests-setup ()
+  (evil-mode)
+  (evil-normal-state)
+  (let ((inhibit-message t))
+    (rust-ts-mode))
+  (indent-tabs-mode -1)
+  (evil-ts-obj-mode 1))
+
+(ert-deftest evil-ts-obj-rust-text-objects-test ()
+  (skip-unless (treesit-ready-p 'rust))
+  (ert-test-erts-file (ert-resource-file "text-objects.erts")))
+
+(ert-deftest evil-ts-obj-rust-movement-test ()
+  (skip-unless (treesit-ready-p 'rust))
+  (ert-test-erts-file (ert-resource-file "movement.erts")))
+
+(ert-deftest evil-ts-obj-rust-edit-test ()
+  (skip-unless (treesit-ready-p 'rust))
+  (ert-test-erts-file (ert-resource-file "edit.erts")))
+
+
+(provide 'evil-ts-obj-rust-tests)
+;;; evil-ts-obj-rust-tests.el ends here


### PR DESCRIPTION
I've found this package very useful. I wanted to understand Emacs's tree-sitter integration better, so I thought, I should take a jab at adding support for Rust.

I've based the tests on the C++ ones, removed the ones that don't make sense for Rust (braces are must have around `if`/`for` and such constructs), also added extra tests for new syntax constructs, like macro invocation, attributes and generic constraints.