### PR TITLE
Extend Rust support with `enum` variants, `trait` associated types and signatures

### DIFF
--- a/lisp/evil-ts-obj-rust.el
+++ b/lisp/evil-ts-obj-rust.el
@@ -46,7 +46,7 @@
   :set #'evil-ts-obj-conf-nodes-setter)
 
 (defcustom evil-ts-obj-rust-statement-seps
-  '("&&" "||")
+  '("&&" "||" ",")
   "Separators for rust statements."
   :type '(repeat string)
   :group 'evil-ts-obj)

--- a/lisp/evil-ts-obj-rust.el
+++ b/lisp/evil-ts-obj-rust.el
@@ -40,7 +40,9 @@
     "expression_statement"
     "return_expression"
     "call_expression"
-    "enum_variant")
+    "enum_variant"
+    "function_signature_item"
+    "associated_type")
   "Nodes that designate simple statement in rust."
   :type '(repeat string)
   :group 'evil-ts-obj

--- a/lisp/evil-ts-obj-rust.el
+++ b/lisp/evil-ts-obj-rust.el
@@ -39,7 +39,8 @@
     "let_declaration"
     "expression_statement"
     "return_expression"
-    "call_expression")
+    "call_expression"
+    "enum_variant")
   "Nodes that designate simple statement in rust."
   :type '(repeat string)
   :group 'evil-ts-obj

--- a/test/evil-ts-obj-rust-resources/text-objects.erts
+++ b/test/evil-ts-obj-rust-resources/text-objects.erts
@@ -524,3 +524,18 @@ i = |5 * 2;
 =-=
 i = |;
 =-=-=
+
+Name: Delete statement outer t10
+
+=-=
+struct S {
+    f1: i32,
+|    f2: i32,
+    f3: i32,
+}
+=-=
+struct S {
+    f1: i32,
+    |f3: i32,
+}
+=-=-=

--- a/test/evil-ts-obj-rust-resources/text-objects.erts
+++ b/test/evil-ts-obj-rust-resources/text-objects.erts
@@ -539,3 +539,49 @@ struct S {
     |f3: i32,
 }
 =-=-=
+
+Name: Delete statement outer t11
+
+=-=
+enum E {
+    Variant1,
+    |Variant2(usize, i32),
+    Variant3 { a: usize, b: i32 },
+}
+=-=
+enum E {
+    Variant1,
+    |Variant3 { a: usize, b: i32 },
+}
+=-=-=
+
+Name: Delete statement outer t12
+
+=-=
+enum E {
+    Variant1,
+    Variant2(usize, i32),
+    |Variant3 { a: usize, b: i32 },
+}
+=-=
+enum E {
+    Variant1,
+    Variant2(usize, i32),|
+}
+=-=-=
+
+Name: Delete statement outer t13
+
+=-=
+enum E {
+    Variant1,
+    Variant2(usize, i32),
+    Variant3 { |a: usize, b: i32 },
+}
+=-=
+enum E {
+    Variant1,
+    Variant2(usize, i32),
+    Variant3 { |b: i32 },
+}
+=-=-=

--- a/test/evil-ts-obj-rust-resources/text-objects.erts
+++ b/test/evil-ts-obj-rust-resources/text-objects.erts
@@ -585,3 +585,76 @@ enum E {
     Variant3 { |b: i32 },
 }
 =-=-=
+
+Name: Delete statement outer t14
+
+=-=
+trait T {
+    |type A;
+
+    fn f(&self) -> Self;
+
+    fn g(&self) {
+        println!("{}", self.f());
+    }
+}
+=-=
+trait T {
+    |
+
+    fn f(&self) -> Self;
+
+    fn g(&self) {
+        println!("{}", self.f());
+    }
+}
+=-=-=
+
+Name: Delete statement outer t15
+
+=-=
+trait T {
+    type A;
+
+    |fn f(&self) -> Self;
+
+    fn g(&self) {
+        println!("{}", self.f());
+    }
+}
+=-=
+trait T {
+    type A;
+
+    |
+
+    fn g(&self) {
+        println!("{}", self.f());
+    }
+}
+=-=-=
+
+Name: Delete statement outer t16
+
+=-=
+trait T {
+    type A;
+
+    fn f(&self) -> Self;
+
+    |fn g(&self) {
+        println!("{}", self.f());
+    }
+}
+=-=
+trait T {
+    type A;
+
+    fn f(&self) -> Self;
+
+    fn g(&self) {
+        |
+    }
+}
+=-=-=
+


### PR DESCRIPTION
I am a bit unsure about adding `,` to statement separators in 479d510d5d7f0cd0d4c35066933b9084893bd390, but that makes struct and enum field outer text object work more sensibly.